### PR TITLE
feat: Allow manual product ID input and prevent duplicates

### DIFF
--- a/ProyectoVentas/src/servicios/ServicioInventario.java
+++ b/ProyectoVentas/src/servicios/ServicioInventario.java
@@ -44,5 +44,21 @@ public class ServicioInventario {
     public List<Producto> listarProductos() {
         return datos.listarProductos();
     }
+
+    /**
+     * Agrega un nuevo producto al inventario.
+     * Verifica primero si el ID del producto ya existe.
+     *
+     * @param p El producto a agregar.
+     * @throws SQLException Si ocurre un error de base de datos durante la inserción.
+     * @throws Exception Si el ID del producto ya existe.
+     */
+    public void agregarNuevoProducto(Producto p) throws SQLException, Exception {
+        if (datos.idExiste(p.id())) {
+            throw new Exception("El ID de producto '" + p.id() + "' ya existe.");
+        }
+        // Si ocurre un error durante la inserción, ProductoDatos.insertar(p) lanzará SQLException
+        datos.insertar(p);
+    }
 }
 

--- a/ProyectoVentas/src/ui/productos/AltaYBaja.java
+++ b/ProyectoVentas/src/ui/productos/AltaYBaja.java
@@ -280,16 +280,23 @@ public class AltaYBaja extends javax.swing.JFrame {
         // 4) Insertar o actualizar (o eliminar si no está activo)
         if (activo) {
             Optional<Producto> existente = datos.buscarPorId(id);
-            if (existente.isPresent()) {
+            if (existente.isPresent()) { // Product exists, so update it
                 datos.actualizar(p);
-            } else {
-                // insertar y obtener el ID generado
-                int nuevoId = datos.insertar(p);
-                txtID.setText(String.valueOf(nuevoId));
+                JOptionPane.showMessageDialog(this,
+                    "Producto actualizado correctamente", // Changed message for clarity
+                    "Éxito", JOptionPane.INFORMATION_MESSAGE);
+            } else { // Product does not exist, so try to insert it
+                if (datos.idExiste(id)) { // Check if the chosen ID is already taken by another product
+                    JOptionPane.showMessageDialog(this,
+                        "Error: El ID de producto '" + id + "' ya existe. Por favor, elija un ID diferente.",
+                        "Error de Duplicado", JOptionPane.ERROR_MESSAGE);
+                } else {
+                    datos.insertar(p); // 'insertar' is now void
+                    JOptionPane.showMessageDialog(this,
+                        "Producto guardado correctamente con ID " + id, // Message confirms user-provided ID
+                        "Éxito", JOptionPane.INFORMATION_MESSAGE);
+                }
             }
-            JOptionPane.showMessageDialog(this,
-                "Producto guardado correctamente",
-                "Éxito", JOptionPane.INFORMATION_MESSAGE);
         } else {
             // baja del producto
             if (datos.buscarPorId(id).isEmpty()) {

--- a/cafeteria.sql
+++ b/cafeteria.sql
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS `administradores` (
 -- --------------------------------------------------------
 DROP TABLE IF EXISTS `productos`;
 CREATE TABLE IF NOT EXISTS `productos` (
-  `id_producto` int NOT NULL AUTO_INCREMENT COMMENT 'Identificador único del producto',
+  `id_producto` int NOT NULL COMMENT 'Identificador único del producto',
   `nombre` varchar(150) NOT NULL COMMENT 'Nombre del producto',
   `descripción` text COMMENT 'Descripción detallada (opcional)',
   `precio` decimal(10,2) NOT NULL COMMENT 'Precio de venta unitario',


### PR DESCRIPTION
feat: Permitir ID de producto manual al añadir nuevos productos

Este cambio introduce la capacidad de asignar IDs de producto manualmente al añadir nuevos
productos al sistema, en lugar de depender de la auto-generación.

Detalles de los cambios:
- Se eliminó `AUTO_INCREMENT` de la columna `id_producto` en el esquema de la tabla `productos`.
- Se actualizó `ProductoDatos.java` para gestionar la inserción manual de IDs
  y se añadió un método para verificar la existencia de IDs.
- Se modificó la interfaz de usuario (UI) de `AltaYBaja.java` para:
    - Utilizar el ID proporcionado por el usuario para los nuevos productos.
    - Verificar si un ID ya existe antes de realizar la inserción.
    - Mostrar un mensaje de error claro si se introduce un ID duplicado.
- Se añadió `ServicioInventario.agregarNuevoProducto` para mejorar la encapsulación
  lógica, aunque la refactorización de la UI para hacer uso de este método se ha pospuesto.

Esto soluciona el problema donde los IDs de producto se autogeneraban y no podían ser
reutilizados o asignados manualmente, y garantiza que no se puedan crear productos con
IDs en conflicto o duplicados.