### PR TITLE
Fix connection handling in report query

### DIFF
--- a/ProyectoVentas/src/datos/VentaDatos.java
+++ b/ProyectoVentas/src/datos/VentaDatos.java
@@ -144,8 +144,8 @@ public class VentaDatos {
             }
         } finally {
             if (cx != null) {
-                // cx.setAutoCommit(true); // Assuming default is true and was not changed for read.
-                cx.close();
+                // Do not close the shared connection managed by ConexionBD.
+                // Simply ensure any open resources have been released.
             }
         }
         return ventasDisplay;


### PR DESCRIPTION
## Summary
- avoid closing the shared DB connection in `VentaDatos.obtenerVentasParaDisplay`

## Testing
- `ant -noinput -q`

------
https://chatgpt.com/codex/tasks/task_e_683f39d4c698833290af38b1562ed7dc