### PR TITLE
Fix: Navigate to login after initial admin creation

### DIFF
--- a/ProyectoVentas/src/ui/admin/CrearAdminFrame.java
+++ b/ProyectoVentas/src/ui/admin/CrearAdminFrame.java
@@ -305,6 +305,8 @@ public class CrearAdminFrame extends javax.swing.JFrame {
                 JOptionPane.showMessageDialog(this,
                         "Administrador creado con éxito",
                         "Éxito", JOptionPane.INFORMATION_MESSAGE);
+                // Navegar a Login después de crear el admin (especialmente el maestro)
+                new LoginFrame().setVisible(true);
                 this.dispose();
             } catch (Exception ex) {
                 JOptionPane.showMessageDialog(this,


### PR DESCRIPTION
Modified CrearAdminFrame.java so that after the initial master administrator is created, the application navigates to the LoginFrame instead of closing directly. This provides a smoother user experience for first-time setup.