### PR TITLE
Fix: Corregir errores en gestión de administradores y transferencia d…

### DIFF
--- a/ProyectoVentas/src/datos/VentaDatos.java
+++ b/ProyectoVentas/src/datos/VentaDatos.java
@@ -150,4 +150,31 @@ public class VentaDatos {
         }
         return ventasDisplay;
     }
+
+    /**
+     * Verifica si existen ventas asociadas a un administrador específico.
+     * @param idAdministrador el ID del administrador a verificar.
+     * @return true si existen ventas, false en caso contrario.
+     * @throws SQLException si ocurre un error de base de datos.
+     */
+    public boolean existenVentasParaAdministrador(int idAdministrador) throws SQLException {
+        String sql = "SELECT COUNT(*) FROM ventas WHERE id_administrador = ?";
+        Connection cx = null;
+        try {
+            cx = ConexionBD.obtener(); // Obtener conexión
+            try (PreparedStatement ps = cx.prepareStatement(sql)) {
+                ps.setInt(1, idAdministrador);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return rs.getInt(1) > 0;
+                    }
+                }
+            }
+        } finally {
+            // No cerramos la conexión aquí ya que es manejada por ConexionBD
+            // Si ConexionBD no maneja un pool y crea nuevas conexiones, debería cerrarse.
+            // Asumiendo que ConexionBD.obtener() devuelve una conexión gestionada o una nueva que se cierra en otro lado.
+        }
+        return false; // Retornar false si no se encuentran o en caso de error no manejado antes.
+    }
 }

--- a/ProyectoVentas/src/entidades/Administrador.java
+++ b/ProyectoVentas/src/entidades/Administrador.java
@@ -20,5 +20,15 @@ public record Administrador(
     public String getUsuario() {
         return this.usuario;
     }
+
+    /**
+     * Devuelve el nombre completo del administrador para ser usado en
+     * componentes de UI como JComboBox o JList.
+     * @return El nombre completo del administrador.
+     */
+    @Override
+    public String toString() {
+        return this.nombreCompleto;
+    }
 }
 


### PR DESCRIPTION
…e rol maestro

- Modifica Administrador.toString() para mostrar solo nombreCompleto en JComboBox.
- Corrige la secuencia de actualización al transferir el rol de admin maestro para evitar errores de duplicidad. Primero se degrada al admin actual y luego se promueve al nuevo.
- Añade verificación para impedir la eliminación de administradores con ventas asociadas, mostrando un mensaje al usuario en lugar de generar un error de FK.