### PR TITLE
Fix: Corregir flujo de gestión de administradores y login

### DIFF
--- a/ProyectoVentas/src/ui/admin/Gestion_Administradores.java
+++ b/ProyectoVentas/src/ui/admin/Gestion_Administradores.java
@@ -420,6 +420,15 @@ public class Gestion_Administradores extends javax.swing.JFrame {
                     @Override
                     public void windowClosed(WindowEvent e) {
                         cargarAdministradores(); // Refresh table after edit frame is closed
+                        if (editarFrame.editorPerdioRolMaestro()) {
+                            // El editor (usuario actual) ya no es Admin Maestro.
+                            // Cerrar esta ventana y mostrar el login.
+                            JOptionPane.showMessageDialog(Gestion_Administradores.this,
+                                    "Su rol de Administrador Maestro ha sido transferido.\nDebe iniciar sesión nuevamente.",
+                                    "Rol Transferido", JOptionPane.INFORMATION_MESSAGE);
+                            new LoginFrame().setVisible(true);
+                            Gestion_Administradores.this.dispose();
+                        }
                     }
                 });
                 editarFrame.setVisible(true);
@@ -439,6 +448,17 @@ public class Gestion_Administradores extends javax.swing.JFrame {
             @Override
             public void windowClosed(WindowEvent e) {
                 cargarAdministradores();
+                // Aunque editorPerdioRolMaestro es principalmente para el flujo de edición,
+                // lo mantenemos aquí por consistencia estructural del listener.
+                // En la práctica, no se espera que sea true en el flujo de nueva creación
+                // según la lógica actual de CrearAdminFrame.
+                if (crearAdminFrame.editorPerdioRolMaestro()) {
+                    JOptionPane.showMessageDialog(Gestion_Administradores.this,
+                            "Su rol de Administrador Maestro ha sido afectado.\nDebe iniciar sesión nuevamente.",
+                            "Rol Modificado", JOptionPane.INFORMATION_MESSAGE);
+                    new LoginFrame().setVisible(true);
+                    Gestion_Administradores.this.dispose();
+                }
             }
         });
         crearAdminFrame.setVisible(true);

--- a/ProyectoVentas/src/ui/login/LoginFrame.java
+++ b/ProyectoVentas/src/ui/login/LoginFrame.java
@@ -12,6 +12,7 @@ public class LoginFrame extends javax.swing.JFrame {
     // Servicio de login (campo manual, fuera de los guarded blocks)
     private final ServicioLogin servicioLogin = new ServicioLogin();
     private int intentosFallidos = 0; // Contador de intentos fallidos
+    private boolean primerAdminFueCreadoExitosamente = false; // Bandera
 
     public LoginFrame() {
         initComponents();
@@ -192,10 +193,47 @@ buttonPanel.setOpaque(false);
     }                                                
 
     private void BtnCrearAdminActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_BtnCrearAdminActionPerformed
-        // Abre ventana de creación de admin
-        new ui.admin.CrearAdminFrame().setVisible(true);
-        this.dispose();
+        // Abre ventana de creación de admin, pasando esta instancia de LoginFrame
+        ui.admin.CrearAdminFrame crearAdminFrame = new ui.admin.CrearAdminFrame(this);
+
+        // Escuchar cuando se cierra CrearAdminFrame
+        crearAdminFrame.addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosed(java.awt.event.WindowEvent windowEvent) {
+                if (!primerAdminFueCreadoExitosamente) {
+                    // Si CrearAdminFrame se cerró (ej. por cancelación) y el primer admin NO fue creado,
+                    // volver a mostrar este LoginFrame.
+                    LoginFrame.this.setVisible(true);
+                    // Re-evaluar estado de botones por si acaso, aunque no debería haber cambiado
+                    AdministradorDatos adminDatosCheck = new AdministradorDatos();
+                    if (!adminDatosCheck.existeAdminMaestro()) {
+                        BtnCrearAdmin.setVisible(true);
+                        btnIniciarSesion.setVisible(false);
+                    } else {
+                        BtnCrearAdmin.setVisible(false);
+                        btnIniciarSesion.setVisible(true);
+                    }
+                }
+                // Si primerAdminFueCreadoExitosamente es true, este LoginFrame ya se habrá cerrado
+                // y uno nuevo se habrá abierto desde primerAdminMaestroCreado().
+            }
+        });
+
+        crearAdminFrame.setVisible(true);
+        this.setVisible(false); // Ocultar este LoginFrame en lugar de cerrarlo
     }//GEN-LAST:event_BtnCrearAdminActionPerformed
+
+    /**
+     * Este método es llamado por CrearAdminFrame cuando el primer administrador maestro
+     * ha sido creado exitosamente.
+     */
+    public void primerAdminMaestroCreado() {
+        this.primerAdminFueCreadoExitosamente = true;
+        // Cerrar esta instancia de LoginFrame (que está oculta)
+        this.dispose();
+        // Abrir una nueva instancia de LoginFrame, que ahora mostrará el botón de Iniciar Sesión
+        SwingUtilities.invokeLater(() -> new LoginFrame().setVisible(true));
+    }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton BtnCrearAdmin;


### PR DESCRIPTION
Se corrigen varios bugs relacionados con la pantalla de login que aparecía incorrectamente y la gestión de roles de Administrador Maestro.

Cambios principales:
- Evita pantalla de login al fallar la degradación del único Admin Maestro.
- Permite al Admin Maestro transferir su rol a otro usuario al editarlo. Si el editor transfiere su rol, es redirigido al login.
- Asegura que al crear/editar admins (sin transferencia de rol que afecte al editor), se regrese a la gestión de usuarios.
- Corrige botón 'Cancelar' en CrearAdminFrame para solo cerrar el diálogo.
- Ajusta flujo de creación del primer Admin Maestro para actualizar correctamente LoginFrame.